### PR TITLE
Output warning instead of fail if a dependency could not be found

### DIFF
--- a/Sources/SwiftDependencyUpdaterLibrary/SubCommands/UpdateCommand.swift
+++ b/Sources/SwiftDependencyUpdaterLibrary/SubCommands/UpdateCommand.swift
@@ -11,7 +11,7 @@ struct UpdateCommand: ParsableCommand {
     func run() throws {
         let folder = URL(fileURLWithPath: folder)
         guard folder.hasDirectoryPath else {
-            print("Folder argument must be a directory.")
+            print("Folder argument must be a directory.".red)
             throw ExitCode.failure
         }
         do {
@@ -34,7 +34,7 @@ struct UpdateCommand: ParsableCommand {
                 }
             }
         } catch {
-            print(error.localizedDescription)
+            print(error.localizedDescription.red)
             throw ExitCode.failure
         }
     }

--- a/Sources/SwiftDependencyUpdaterLibrary/Update.swift
+++ b/Sources/SwiftDependencyUpdaterLibrary/Update.swift
@@ -55,8 +55,9 @@ enum Update: Equatable {
                     try shellOut(to: "swift", arguments: ["package", "--package-path", "\"\(folder.path)\"", "update", "resolve", ])
                     print("Resolved Version".green)
                 }
-            } catch SwiftPackageError.resultCountMismatch(let name, let count) where count == 0 {
-                print("Warning: Could not find version requirement for \(name) in Package.swift - this could be due to the dependency only beeing required on a specific platform.".yellow)
+            } catch let SwiftPackageError.resultCountMismatch(name, count) where count == 0 { // false positive, count is an integer swiftlint:disable:this empty_count
+                print("Warning: Could not find version requirement for \(name) in Package.swift - " +
+                      "this could be due to the dependency only beeing required on a specific platform.".yellow)
             } catch {
                 throw error
             }

--- a/Sources/SwiftDependencyUpdaterLibrary/Update.swift
+++ b/Sources/SwiftDependencyUpdaterLibrary/Update.swift
@@ -45,15 +45,22 @@ enum Update: Equatable {
         case let .withChangingRequirements(version):
             print("Updating \(dependency.name): \(dependency.resolvedVersion.versionNumberOrRevision) -> \(version)".bold)
             let swiftPackage = SwiftPackage(in: folder)
-            let packageUpdate = try swiftPackage.performUpdate(self, of: dependency)
-            print("Updated Package.swift".green)
-            if packageUpdate {
-                try shellOut(to: "swift", arguments: ["package", "--package-path", "\"\(folder.path)\"", "update", dependency.name ])
-                print("Resolved to new version".green)
-            } else {
-                try shellOut(to: "swift", arguments: ["package", "--package-path", "\"\(folder.path)\"", "update", "resolve", ])
-                print("Resolved Version".green)
+            do {
+                let packageUpdate = try swiftPackage.performUpdate(self, of: dependency)
+                print("Updated Package.swift".green)
+                if packageUpdate {
+                    try shellOut(to: "swift", arguments: ["package", "--package-path", "\"\(folder.path)\"", "update", dependency.name ])
+                    print("Resolved to new version".green)
+                } else {
+                    try shellOut(to: "swift", arguments: ["package", "--package-path", "\"\(folder.path)\"", "update", "resolve", ])
+                    print("Resolved Version".green)
+                }
+            } catch SwiftPackageError.resultCountMismatch(let name, let count) where count == 0 {
+                print("Warning: Could not find version requirement for \(name) in Package.swift - this could be due to the dependency only beeing required on a specific platform.".yellow)
+            } catch {
+                throw error
             }
+
         case let .withoutChangingRequirements(version):
             print("Updating \(dependency.name): \(dependency.resolvedVersion.versionNumberOrRevision) -> \(version)".bold)
             try shellOut(to: "swift", arguments: ["package", "--package-path", "\"\(folder.path)\"", "update", dependency.name, ])


### PR DESCRIPTION
In case a dependency is not required on all platforms, it might not
be defined - in this case show a warning instead of fail.